### PR TITLE
Add collapsible shift sections

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4,9 +4,28 @@ header, footer { background: #333; color: #fff; padding: 1em; }
 nav a { color: #fff; margin-right: 1em; text-decoration: none; }
 nav a:hover { text-decoration: underline; }
 main { padding: 1em; }
-.task { border: 1px solid #ccc; padding: 0.5em; margin-bottom: 0.5em; background: #fff; border-radius: 4px; }
+.task { border: 1px solid #ccc; padding: 0.5em; margin: 0.5em; background: #fff; border-radius: 4px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
 .users { width: 100%; border-collapse: collapse; margin-top: 1em; }
 .users th, .users td { border: 1px solid #ccc; padding: 0.5em; text-align: left; }
 .state-Pendiente { border-left: 4px solid #f39c12; }
 .state-En_proceso { border-left: 4px solid #3498db; }
 .state-Realizada { border-left: 4px solid #2ecc71; text-decoration: line-through; }
+
+.shift {
+    margin-bottom: 1em;
+}
+.shift-header {
+    cursor: pointer;
+    background: #eee;
+    padding: 0.5em;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    margin: 0;
+}
+.shift-notes {
+    display: none;
+    padding: 0.5em;
+}
+.shift-notes.open {
+    display: block;
+}

--- a/index.php
+++ b/index.php
@@ -13,7 +13,9 @@ $stmt->execute();
 $notes = $stmt->fetchAll();
 $shifts = ['Matutino', 'Vespertino', 'Nocturno'];
 foreach ($shifts as $shift_name) {
-    echo "<h2>Turno $shift_name</h2>";
+    echo "<div class='shift'>";
+    echo "<h2 class='shift-header'>Turno $shift_name</h2>";
+    echo "<div class='shift-notes'>";
     foreach ($notes as $note) {
         if ($note['shift'] === $shift_name) {
             $title = htmlspecialchars($note['title'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
@@ -24,4 +26,7 @@ foreach ($shifts as $shift_name) {
             echo "</div>";
         }
     }
-}include 'templates/footer.php';
+    echo "</div>"; // shift-notes
+    echo "</div>"; // shift
+}
+include 'templates/footer.php';

--- a/js/app.js
+++ b/js/app.js
@@ -1,4 +1,10 @@
 // js/app.js
 document.addEventListener('DOMContentLoaded', () => {
     // Aquí puedes añadir código AJAX para cambiar estados sin recargar
+    document.querySelectorAll('.shift-header').forEach(header => {
+        header.addEventListener('click', () => {
+            const notes = header.nextElementSibling;
+            notes.classList.toggle('open');
+        });
+    });
 });


### PR DESCRIPTION
## Summary
- organize notes by collapsible shifts
- toggle shift notes with JavaScript
- style shifts as clickable sections with cards

## Testing
- `php -l index.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686edee6af4083259947c90c2aa6b12b