### PR TITLE
Add inline note creation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4,9 +4,40 @@ header, footer { background: #333; color: #fff; padding: 1em; }
 nav a { color: #fff; margin-right: 1em; text-decoration: none; }
 nav a:hover { text-decoration: underline; }
 main { padding: 1em; }
-.task { border: 1px solid #ccc; padding: 0.5em; margin-bottom: 0.5em; background: #fff; border-radius: 4px; }
+.task { border: 1px solid #ccc; padding: 0.5em; margin: 0.5em; background: #fff; border-radius: 4px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
 .users { width: 100%; border-collapse: collapse; margin-top: 1em; }
 .users th, .users td { border: 1px solid #ccc; padding: 0.5em; text-align: left; }
 .state-Pendiente { border-left: 4px solid #f39c12; }
 .state-En_proceso { border-left: 4px solid #3498db; }
 .state-Realizada { border-left: 4px solid #2ecc71; text-decoration: line-through; }
+
+.shift {
+    margin-bottom: 1em;
+}
+.shift-header {
+    cursor: pointer;
+    background: #eee;
+    padding: 0.5em;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    margin: 0;
+}
+.shift-notes {
+    display: none;
+    padding: 0.5em;
+}
+.shift-notes.open {
+    display: block;
+}
+
+.new-note-form {
+    margin-top: 0.5em;
+    padding: 0.5em;
+    border: 1px dashed #ccc;
+    background: #fafafa;
+    border-radius: 4px;
+}
+.new-note-form input[type=text], .new-note-form textarea {
+    width: 100%;
+    margin-bottom: 0.5em;
+}

--- a/index.php
+++ b/index.php
@@ -5,23 +5,51 @@ if (!isset($_SESSION['user'])) {
     exit;
 }
 require 'config/db.php';
+$shifts = ['Matutino', 'Vespertino', 'Nocturno'];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $title = trim($_POST['title'] ?? '');
+    $description = trim($_POST['description'] ?? '');
+    $shift = $_POST['shift'] ?? '';
+    if ($title && in_array($shift, $shifts, true)) {
+        $stmt = $pdo->prepare("INSERT INTO notes (title, description, state, date, shift, created_by) VALUES (?, ?, 'Pendiente', CURDATE(), ?, ?)");
+        $stmt->execute([$title, $description, $shift, $_SESSION['user']]);
+    }
+    header('Location: index.php');
+    exit;
+}
+
 include 'templates/header.php';
 
 // Obtener notas del día actual
 $stmt = $pdo->prepare("SELECT * FROM notes WHERE date = CURDATE() ORDER BY shift, id");
 $stmt->execute();
 $notes = $stmt->fetchAll();
-$shifts = ['Matutino', 'Vespertino', 'Nocturno'];
 foreach ($shifts as $shift_name) {
-    echo "<h2>Turno $shift_name</h2>";
+    echo "<div class='shift'>";
+    echo "<h2 class='shift-header'>Turno $shift_name</h2>";
+    echo "<div class='shift-notes'>";
     foreach ($notes as $note) {
         if ($note['shift'] === $shift_name) {
             $title = htmlspecialchars($note['title'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
             $stateClass = 'state-' . str_replace(' ', '_', $note['state']);
+            $desc = htmlspecialchars($note['description'] ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
             echo "<div class='task {$stateClass}'>";
-            echo "<a href='note_details.php?id={$note['id']}'><strong>{$title}</strong></a> ";
-            echo "[{$note['state']}] <em>{$note['date']}</em>";
+            echo "<div class='task-header'>";
+            echo "<strong>{$title}</strong> [{$note['state']}] <em>{$note['date']}</em> ";
+            echo "<a href='note_details.php?id={$note['id']}'>Editar</a>";
+            echo "</div>";
+            echo "<div class='task-desc' style='display:none'>{$desc}</div>";
             echo "</div>";
         }
     }
-}include 'templates/footer.php';
+    echo "<form method='POST' class='new-note-form'>";
+    echo "<input type='hidden' name='shift' value='{$shift_name}'>";
+    echo "<input type='text' name='title' placeholder='Nueva nota' required>";
+    echo "<textarea name='description' placeholder='Descripción'></textarea>";
+    echo "<button type='submit'>Agregar</button>";
+    echo "</form>";
+    echo "</div>"; // shift-notes
+    echo "</div>"; // shift
+}
+include 'templates/footer.php';

--- a/js/app.js
+++ b/js/app.js
@@ -1,4 +1,16 @@
 // js/app.js
 document.addEventListener('DOMContentLoaded', () => {
     // Aquí puedes añadir código AJAX para cambiar estados sin recargar
+    document.querySelectorAll('.shift-header').forEach(header => {
+        header.addEventListener('click', () => {
+            const notes = header.nextElementSibling;
+            notes.classList.toggle('open');
+        });
+    });
+    document.querySelectorAll('.task-header').forEach(th => {
+        th.addEventListener('click', () => {
+            const desc = th.nextElementSibling;
+            if (desc) desc.style.display = desc.style.display === 'none' ? 'block' : 'none';
+        });
+    });
 });


### PR DESCRIPTION
## Summary
- allow creating notes per shift on the main page
- show note descriptions inline and provide edit link
- toggle note details with JS
- basic styling for new note form

## Testing
- `php -l index.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686edee6af4083259947c90c2aa6b12b