### PR TITLE
Add shift-archiving and user management

### DIFF
--- a/archived.php
+++ b/archived.php
@@ -5,16 +5,30 @@ if (!isset($_SESSION['user'])) {
     exit;
 }
 require 'config/db.php';
+$shifts = ['Matutino', 'Vespertino', 'Nocturno'];
 include 'templates/header.php';
 echo '<h2>Notas Archivadas</h2>';
-$stmt = $pdo->prepare("SELECT * FROM notes WHERE date < CURDATE() ORDER BY date DESC");
+$stmt = $pdo->prepare("SELECT * FROM notes WHERE state = 'Realizada' OR date < CURDATE() ORDER BY shift, date DESC, id");
 $stmt->execute();
 $notes = $stmt->fetchAll();
-foreach ($notes as $note) {
-    $title = htmlspecialchars($note['title'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
-    $stateClass = 'state-' . str_replace(' ', '_', $note['state']);
-    echo "<div class='task {$stateClass}'>";
-    echo "<a href='note_details.php?id={$note['id']}'><strong>{$title}</strong></a> ";
-    echo "[{$note['state']}] <em>{$note['date']}</em>";
-    echo "</div>";
-}include 'templates/footer.php'; ?>
+foreach ($shifts as $shift_name) {
+    echo "<div class='shift'>";
+    echo "<h2 class='shift-header'>Turno $shift_name</h2>";
+    echo "<div class='shift-notes'>";
+    foreach ($notes as $note) {
+        if ($note['shift'] === $shift_name) {
+            $title = htmlspecialchars($note['title'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+            $stateClass = 'state-' . str_replace(' ', '_', $note['state']);
+            $desc = htmlspecialchars($note['description'] ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+            echo "<div class='task {$stateClass}'>";
+            echo "<div class='task-header'>";
+            echo "<strong>{$title}</strong> [{$note['state']}] <em>{$note['date']}</em> ";
+            echo "<a href='note_details.php?id={$note['id']}'>Editar</a>";
+            echo "</div>";
+            echo "<div class='task-desc' style='display:none'>{$desc}</div>";
+            echo "</div>";
+        }
+    }
+    echo "</div></div>";
+}
+include 'templates/footer.php'; ?>

--- a/css/style.css
+++ b/css/style.css
@@ -4,9 +4,40 @@ header, footer { background: #333; color: #fff; padding: 1em; }
 nav a { color: #fff; margin-right: 1em; text-decoration: none; }
 nav a:hover { text-decoration: underline; }
 main { padding: 1em; }
-.task { border: 1px solid #ccc; padding: 0.5em; margin-bottom: 0.5em; background: #fff; border-radius: 4px; }
+.task { border: 1px solid #ccc; padding: 0.5em; margin: 0.5em; background: #fff; border-radius: 4px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
 .users { width: 100%; border-collapse: collapse; margin-top: 1em; }
 .users th, .users td { border: 1px solid #ccc; padding: 0.5em; text-align: left; }
 .state-Pendiente { border-left: 4px solid #f39c12; }
 .state-En_proceso { border-left: 4px solid #3498db; }
 .state-Realizada { border-left: 4px solid #2ecc71; text-decoration: line-through; }
+
+.shift {
+    margin-bottom: 1em;
+}
+.shift-header {
+    cursor: pointer;
+    background: #eee;
+    padding: 0.5em;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    margin: 0;
+}
+.shift-notes {
+    display: none;
+    padding: 0.5em;
+}
+.shift-notes.open {
+    display: block;
+}
+
+.new-note-form {
+    margin-top: 0.5em;
+    padding: 0.5em;
+    border: 1px dashed #ccc;
+    background: #fafafa;
+    border-radius: 4px;
+}
+.new-note-form input[type=text], .new-note-form textarea {
+    width: 100%;
+    margin-bottom: 0.5em;
+}

--- a/index.php
+++ b/index.php
@@ -5,23 +5,51 @@ if (!isset($_SESSION['user'])) {
     exit;
 }
 require 'config/db.php';
+$shifts = ['Matutino', 'Vespertino', 'Nocturno'];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $title = trim($_POST['title'] ?? '');
+    $description = trim($_POST['description'] ?? '');
+    $shift = $_POST['shift'] ?? '';
+    if ($title && in_array($shift, $shifts, true)) {
+        $stmt = $pdo->prepare("INSERT INTO notes (title, description, state, date, shift, created_by) VALUES (?, ?, 'Pendiente', CURDATE(), ?, ?)");
+        $stmt->execute([$title, $description, $shift, $_SESSION['user']]);
+    }
+    header('Location: index.php');
+    exit;
+}
+
 include 'templates/header.php';
 
 // Obtener notas del día actual
-$stmt = $pdo->prepare("SELECT * FROM notes WHERE date = CURDATE() ORDER BY shift, id");
+$stmt = $pdo->prepare("SELECT * FROM notes WHERE date = CURDATE() AND state != 'Realizada' ORDER BY shift, id");
 $stmt->execute();
 $notes = $stmt->fetchAll();
-$shifts = ['Matutino', 'Vespertino', 'Nocturno'];
 foreach ($shifts as $shift_name) {
-    echo "<h2>Turno $shift_name</h2>";
+    echo "<div class='shift'>";
+    echo "<h2 class='shift-header'>Turno $shift_name</h2>";
+    echo "<div class='shift-notes'>";
     foreach ($notes as $note) {
         if ($note['shift'] === $shift_name) {
             $title = htmlspecialchars($note['title'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
             $stateClass = 'state-' . str_replace(' ', '_', $note['state']);
+            $desc = htmlspecialchars($note['description'] ?? '', ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
             echo "<div class='task {$stateClass}'>";
-            echo "<a href='note_details.php?id={$note['id']}'><strong>{$title}</strong></a> ";
-            echo "[{$note['state']}] <em>{$note['date']}</em>";
+            echo "<div class='task-header'>";
+            echo "<strong>{$title}</strong> [{$note['state']}] <em>{$note['date']}</em> ";
+            echo "<a href='note_details.php?id={$note['id']}'>Editar</a>";
+            echo "</div>";
+            echo "<div class='task-desc' style='display:none'>{$desc}</div>";
             echo "</div>";
         }
     }
-}include 'templates/footer.php';
+    echo "<form method='POST' class='new-note-form'>";
+    echo "<input type='hidden' name='shift' value='{$shift_name}'>";
+    echo "<input type='text' name='title' placeholder='Nueva nota' required>";
+    echo "<textarea name='description' placeholder='Descripción'></textarea>";
+    echo "<button type='submit'>Agregar</button>";
+    echo "</form>";
+    echo "</div>"; // shift-notes
+    echo "</div>"; // shift
+}
+include 'templates/footer.php';

--- a/js/app.js
+++ b/js/app.js
@@ -1,4 +1,16 @@
 // js/app.js
 document.addEventListener('DOMContentLoaded', () => {
     // Aquí puedes añadir código AJAX para cambiar estados sin recargar
+    document.querySelectorAll('.shift-header').forEach(header => {
+        header.addEventListener('click', () => {
+            const notes = header.nextElementSibling;
+            notes.classList.toggle('open');
+        });
+    });
+    document.querySelectorAll('.task-header').forEach(th => {
+        th.addEventListener('click', () => {
+            const desc = th.nextElementSibling;
+            if (desc) desc.style.display = desc.style.display === 'none' ? 'block' : 'none';
+        });
+    });
 });

--- a/note_details.php
+++ b/note_details.php
@@ -13,7 +13,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $description = $_POST['description'];
     $stmt = $pdo->prepare("UPDATE notes SET state = ?, description = ? WHERE id = ?");
     $stmt->execute([$state, $description, $id]);
-    header("Location: note_details.php?id=$id");
+    if ($state === 'Realizada') {
+        header('Location: archived.php');
+    } else {
+        header("Location: note_details.php?id=$id");
+    }
     exit;
 }
 $stmt = $pdo->prepare("SELECT * FROM notes WHERE id = ?");

--- a/templates/header.php
+++ b/templates/header.php
@@ -13,6 +13,8 @@
         <a href="archived.php">Archivadas</a> |
         <?php if (isset($_SESSION['role']) && $_SESSION['role'] === 'admin'): ?>
             <a href="users.php">Usuarios</a> |
+        <?php else: ?>
+            <a href="users.php">Mi cuenta</a> |
         <?php endif; ?>
         <a href="logout.php">Cerrar sesión</a>
     </nav>

--- a/users.php
+++ b/users.php
@@ -1,24 +1,52 @@
 <?php
 session_start();
-if (!isset($_SESSION['user']) || $_SESSION['role'] !== 'admin') {
-    header('Location: index.php');
+if (!isset($_SESSION['user'])) {
+    header('Location: login.php');
     exit;
 }
+$isAdmin = $_SESSION['role'] === 'admin';
 require 'config/db.php';
 $error = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = $_POST['action'] ?? '';
     $username = $_POST['username'] ?? '';
+    $password = trim($_POST['password'] ?? '');
     $role = $_POST['role'] ?? 'receptionist';
-    $password = $_POST['password'] ?? '';
-    if ($username && $password) {
-        $hash = password_hash($password, PASSWORD_DEFAULT);
-        $stmt = $pdo->prepare('INSERT INTO users (username, role, password) VALUES (?, ?, ?)');
-        $stmt->execute([$username, $role, $hash]);
-    } else {
-        $error = 'Usuario y contraseña requeridos';
+    if ($action === 'create' && $isAdmin) {
+        if ($username && $password) {
+            $hash = password_hash($password, PASSWORD_DEFAULT);
+            $stmt = $pdo->prepare('INSERT INTO users (username, role, password) VALUES (?, ?, ?)');
+            $stmt->execute([$username, $role, $hash]);
+        } else {
+            $error = 'Usuario y contraseña requeridos';
+        }
+    } elseif ($action === 'update' && ($isAdmin || $username === $_SESSION['user'])) {
+        $fields = [];
+        $params = [];
+        if ($password !== '') {
+            $fields[] = 'password = ?';
+            $params[] = password_hash($password, PASSWORD_DEFAULT);
+        }
+        if ($isAdmin) {
+            $fields[] = 'role = ?';
+            $params[] = $role;
+        }
+        if ($fields) {
+            $params[] = $username;
+            $stmt = $pdo->prepare('UPDATE users SET ' . implode(', ', $fields) . ' WHERE username = ?');
+            $stmt->execute($params);
+        }
+    } elseif ($action === 'delete' && $isAdmin) {
+        $stmt = $pdo->prepare('DELETE FROM users WHERE username = ?');
+        $stmt->execute([$username]);
     }
 }
-$stmt = $pdo->query('SELECT username, role FROM users ORDER BY username');
+$stmt = $pdo->prepare($isAdmin ? 'SELECT username, role FROM users ORDER BY username' : 'SELECT username, role FROM users WHERE username = ?');
+if ($isAdmin) {
+    $stmt->execute();
+} else {
+    $stmt->execute([$_SESSION['user']]);
+}
 $users = $stmt->fetchAll();
 include 'templates/header.php';
 ?>
@@ -27,13 +55,47 @@ include 'templates/header.php';
 <p style="color:red;"><?= htmlspecialchars($error) ?></p>
 <?php endif; ?>
 <table class="users">
-    <tr><th>Usuario</th><th>Rol</th></tr>
+    <tr>
+        <th>Usuario</th>
+        <th>Rol</th>
+        <?php if ($isAdmin): ?><th>Acciones</th><?php endif; ?>
+    </tr>
     <?php foreach ($users as $u): ?>
-    <tr><td><?= htmlspecialchars($u['username']) ?></td><td><?= htmlspecialchars($u['role']) ?></td></tr>
+    <tr>
+        <td><?= htmlspecialchars($u['username']) ?></td>
+        <td><?= htmlspecialchars($u['role']) ?></td>
+        <?php if ($isAdmin): ?>
+        <td>
+            <form method="POST" style="display:inline;">
+                <input type="hidden" name="action" value="delete">
+                <input type="hidden" name="username" value="<?= htmlspecialchars($u['username']) ?>">
+                <button type="submit" onclick="return confirm('¿Eliminar usuario?');">Eliminar</button>
+            </form>
+        </td>
+        <?php endif; ?>
+    </tr>
+    <tr>
+        <td colspan="<?= $isAdmin ? 3 : 2 ?>">
+            <form method="POST">
+                <input type="hidden" name="action" value="update">
+                <input type="hidden" name="username" value="<?= htmlspecialchars($u['username']) ?>">
+                <input type="password" name="password" placeholder="Nueva contraseña">
+                <?php if ($isAdmin): ?>
+                    <select name="role">
+                        <option value="receptionist" <?= $u['role'] === 'receptionist' ? 'selected' : '' ?>>Recepcionista</option>
+                        <option value="admin" <?= $u['role'] === 'admin' ? 'selected' : '' ?>>Admin</option>
+                    </select>
+                <?php endif; ?>
+                <button type="submit">Guardar</button>
+            </form>
+        </td>
+    </tr>
     <?php endforeach; ?>
 </table>
+<?php if ($isAdmin): ?>
 <h3>Añadir usuario</h3>
 <form method="POST">
+    <input type="hidden" name="action" value="create">
     <label>Usuario: <input type="text" name="username" required></label><br>
     <label>Rol:
         <select name="role">
@@ -44,4 +106,5 @@ include 'templates/header.php';
     <label>Contraseña: <input type="password" name="password" required></label><br>
     <button type="submit">Crear</button>
 </form>
+<?php endif; ?>
 <?php include 'templates/footer.php'; ?>


### PR DESCRIPTION
## Summary
- move completed notes to archived page and hide from main view
- group archived notes by shift
- redirect to archive when a note is marked as completed
- let any logged in user edit their password; admins can create, edit and delete users
- show user settings link for non-admins

## Testing
- `php -l index.php` *(fails: `php: command not found`)*
- `php -l note_details.php` *(fails: `php: command not found`)*
- `php -l archived.php` *(fails: `php: command not found`)*
- `php -l users.php` *(fails: `php: command not found`)*
- `php -l templates/header.php` *(fails: `php: command not found`)*


------
https://chatgpt.com/codex/tasks/task_e_686edee6af4083259947c90c2aa6b12b